### PR TITLE
adapt changes in `r1cs-std`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,9 +15,12 @@ ark-poly = { version = "0.3.0", default-features = false }
 ark-relations = { version = "^0.3.0", default-features = false, optional = true}
 tracing = { version = "0.1", default-features = false, features = [ "attributes" ], optional = true}
 
-
 [dev-dependencies]
 ark-test-curves = { version = "^0.3.0", default-features = false, features = ["bls12_381_scalar_field", "mnt4_753_scalar_field"] }
+
+[patch.crates-io]
+ark-sponge = {git = "https://github.com/arkworks-rs/sponge"}
+ark-r1cs-std = {git = "https://github.com/arkworks-rs/r1cs-std", branch = "master"}
 
 [features]
 default = ["std"]

--- a/README.md
+++ b/README.md
@@ -38,6 +38,15 @@ This library comes with some unit and integration tests. Run these tests with:
 cargo test
 ```
 
+To use this library, you need to add the following to your `Cargo.toml`. Note that this configuration will bump `ark-sponge` and `ark-r1cs-std` to `master`/`main` instead of stable version on `crates.io`.
+```toml
+[dependencies]
+ark-ldt = {git = "https://github.com/arkworks-rs/ldt", branch="main", default-features = false}
+
+[patch.crates-io]
+ark-sponge = {git = "https://github.com/arkworks-rs/sponge"}
+ark-r1cs-std = {git = "https://github.com/arkworks-rs/r1cs-std", branch = "master"}
+```
 
 ## License
 

--- a/src/domain/mod.rs
+++ b/src/domain/mod.rs
@@ -186,6 +186,7 @@ mod tests {
         use ark_r1cs_std::alloc::AllocVar;
         use ark_r1cs_std::fields::fp::FpVar;
         use ark_r1cs_std::fields::FieldVar;
+        use ark_r1cs_std::poly::domain::Radix2DomainVar;
         use ark_r1cs_std::poly::evaluations::univariate::EvaluationsVar;
         use ark_r1cs_std::R1CSVar;
         use ark_relations::r1cs::ConstraintSystem;
@@ -222,11 +223,13 @@ mod tests {
                 .iter()
                 .map(|x| FpVar::new_witness(ark_relations::ns!(cs, "eval_var"), || Ok(*x)).unwrap())
                 .collect();
-            let r1cs_coset = ark_r1cs_std::poly::domain::Radix2DomainVar {
-                gen: base_domain.group_gen,
-                offset: FpVar::constant(offset),
-                dim: ark_std::log2(degree.next_power_of_two()) as u64,
-            };
+
+            let r1cs_coset = Radix2DomainVar::new(
+                base_domain.group_gen,
+                ark_std::log2(degree.next_power_of_two()) as u64,
+                FpVar::constant(offset),
+            )
+            .unwrap();
             let eval_var = EvaluationsVar::from_vec_and_domain(eval_var, r1cs_coset, true);
 
             let pt = Fr::rand(&mut rng);

--- a/src/fri/constraints/mod.rs
+++ b/src/fri/constraints/mod.rs
@@ -96,11 +96,7 @@ impl<F: PrimeField> FRIVerifierGadget<F> {
             let query_offset = &FpVar::constant(curr_round_domain.offset)
                 * &(FpVar::constant(curr_round_domain.gen()).pow_le(&curr_coset_index)?);
 
-            let query_coset = Radix2DomainVar {
-                gen: query_gen,
-                offset: query_offset,
-                dim: fri_parameters.localization_parameters[i],
-            };
+            let query_coset = Radix2DomainVar::new(query_gen, fri_parameters.localization_parameters[i], query_offset)?;
 
             queries.push(query_coset);
 
@@ -229,7 +225,7 @@ mod tests {
 
         for i in 0..query_cosets.len() {
             assert_eq!(
-                query_cosets_actual[i].offset.value().unwrap(),
+                query_cosets_actual[i].offset().value().unwrap(),
                 query_cosets[i].offset
             );
             assert_eq!(query_cosets_actual[i].gen, query_cosets[i].gen());
@@ -297,7 +293,7 @@ mod tests {
             query_indices_native[0],
             fri_parameters.localization_parameters[0] as usize,
         );
-        assert_eq!(qi.offset, query_cosets[0].offset.value().unwrap());
+        assert_eq!(qi.offset, query_cosets[0].offset().value().unwrap());
         let answer_input: Vec<_> = indices
             .iter()
             .map(|&i| {
@@ -309,7 +305,7 @@ mod tests {
             query_indices_native[1],
             fri_parameters.localization_parameters[1] as usize,
         );
-        assert_eq!(q0.offset, query_cosets[1].offset.value().unwrap());
+        assert_eq!(q0.offset, query_cosets[1].offset().value().unwrap());
         let answer_round_0: Vec<_> = indices
             .iter()
             .map(|&i| {
@@ -335,7 +331,7 @@ mod tests {
                 .unwrap()
             })
             .collect();
-        assert_eq!(q1.offset, query_cosets[2].offset.value().unwrap());
+        assert_eq!(q1.offset, query_cosets[2].offset().value().unwrap());
 
         let total_shrink_factor: u64 = fri_parameters.localization_parameters.iter().sum();
         let final_poly_degree_bound = fri_parameters.tested_degree >> total_shrink_factor;

--- a/src/fri/constraints/mod.rs
+++ b/src/fri/constraints/mod.rs
@@ -96,7 +96,11 @@ impl<F: PrimeField> FRIVerifierGadget<F> {
             let query_offset = &FpVar::constant(curr_round_domain.offset)
                 * &(FpVar::constant(curr_round_domain.gen()).pow_le(&curr_coset_index)?);
 
-            let query_coset = Radix2DomainVar::new(query_gen, fri_parameters.localization_parameters[i], query_offset)?;
+            let query_coset = Radix2DomainVar::new(
+                query_gen,
+                fri_parameters.localization_parameters[i],
+                query_offset,
+            )?;
 
             queries.push(query_coset);
 


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before hitting that submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

This PR fixes compilation issue cause by `Radix2DomainVar.offset` becoming private. 

closes: #6 

**Warning**: Because `ark-ldt` has not been released on `crates.io` yet, you need to add the following to your `Cargo.toml` to allow this library be compiled correctly: 
```toml
[patch.crates-io]
ark-sponge = {git = "https://github.com/arkworks-rs/sponge"}
ark-r1cs-std = {git = "https://github.com/arkworks-rs/r1cs-std", branch = "master"}
```
Otherwise, use commit `82cd146bf676ed33dfd54429ff40686a62a320da` instead of `main` branch. 

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [x] Targeted PR against correct branch (master)
- [x] Linked to Github issue with discussion and accepted design OR have an explanation in the PR that describes this work.
- [x] Wrote unit tests
- [x] Updated relevant documentation in the code
- [x] Added a relevant changelog entry to the `Pending` section in `CHANGELOG.md`
- [x] Re-reviewed `Files changed` in the Github PR explorer
