### PR TITLE
Remove the no_std workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,36 +76,3 @@ jobs:
             command: test
             args: --release
 
-  check_no_std:
-    name: Check no_std
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-
-      - name: Install Rust (${{ matrix.rust }})
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          target: thumbv6m-none-eabi
-          override: true
-
-      - name: Install Rust ARM64 (${{ matrix.rust }})
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          target: aarch64-unknown-none
-          override: true
-
-      - uses: actions/cache@v2
-        with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            target
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
-
-      - name: ldt
-        run: |
-          cargo build --no-default-features --target aarch64-unknown-none
-          cargo check --examples --no-default-features --target aarch64-unknown-none


### PR DESCRIPTION
What does this PR do?

We'd either need a solution for the errors in https://github.com/arkworks-rs/ldt/pull/10 or alternatively if appropriate we could just remove this check.
